### PR TITLE
Make field names snake case by default

### DIFF
--- a/src/ppx_deriving_graphql.ml
+++ b/src/ppx_deriving_graphql.ml
@@ -12,6 +12,15 @@ let upper_snake s =
   |> List.map String.capitalize_ascii
   |> String.concat ""
 
+let upper_first_lower_snake s =
+  let words =
+    match String.split_on_char '_' s with
+    | s :: rest ->
+        String.uncapitalize_ascii s :: List.map String.capitalize_ascii rest
+    | [] -> []
+  in
+  String.concat "" words
+
 let mangle_name_schema =
   let base = "schema_typ" in
   function "t" -> base | x -> x ^ "_" ^ base
@@ -121,7 +130,7 @@ let record_to_schema ~loc ~label fields =
         in
         [%expr
           Graphql_lwt.Schema.field ?doc:[%e field_doc]
-            [%e estring ~loc field_name]
+            [%e estring ~loc (upper_first_lower_snake field_name)]
             ~typ:[%e type_to_schema field.pld_type]
             ~args:[] ~resolve:[%e accessor_func]
           :: [%e expr_acc]])

--- a/test/passing/simple.expected
+++ b/test/passing/simple.expected
@@ -135,14 +135,14 @@ module A =
                                  })
         let (train_details_schema_typ : (ctx, _) Graphql_lwt.Schema.typ) =
           Graphql_lwt.Schema.obj "TrainDetails"
-            ~fields:[Graphql_lwt.Schema.field ?doc:None "number_of_people"
+            ~fields:[Graphql_lwt.Schema.field ?doc:None "numberOfPeople"
                        ~typ:(Graphql_lwt.Schema.non_null
                                Graphql_lwt.Schema.int) ~args:[]
                        ~resolve:(fun _ -> fun p -> p.number_of_people);
-                    Graphql_lwt.Schema.field ?doc:None "train_type"
+                    Graphql_lwt.Schema.field ?doc:None "trainType"
                       ~typ:(Fun.id Graphql_lwt.Schema.string) ~args:[]
                       ~resolve:(fun _ -> fun p -> p.train_type);
-                    Graphql_lwt.Schema.field ?doc:None "train_class"
+                    Graphql_lwt.Schema.field ?doc:None "trainClass"
                       ~typ:(Graphql_lwt.Schema.non_null
                               train_class_schema_typ) ~args:[]
                       ~resolve:(fun _ -> fun p -> p.train_class);
@@ -221,14 +221,14 @@ module B =
                                  })
         let (train_details_schema_typ : (ctx, _) Graphql_lwt.Schema.typ) =
           Graphql_lwt.Schema.obj "TrainDetails"
-            ~fields:[Graphql_lwt.Schema.field ?doc:None "number_of_people"
+            ~fields:[Graphql_lwt.Schema.field ?doc:None "numberOfPeople"
                        ~typ:(Graphql_lwt.Schema.non_null
                                Graphql_lwt.Schema.int) ~args:[]
                        ~resolve:(fun _ -> fun p -> p.number_of_people);
-                    Graphql_lwt.Schema.field ?doc:None "train_type"
+                    Graphql_lwt.Schema.field ?doc:None "trainType"
                       ~typ:(Fun.id Graphql_lwt.Schema.string) ~args:[]
                       ~resolve:(fun _ -> fun p -> p.train_type);
-                    Graphql_lwt.Schema.field ?doc:None "train_class"
+                    Graphql_lwt.Schema.field ?doc:None "trainClass"
                       ~typ:(Graphql_lwt.Schema.non_null
                               train_class_schema_typ) ~args:[]
                       ~resolve:(fun _ -> fun p -> p.train_class);


### PR DESCRIPTION
It is very common for GraphQL to follow more "Javascript/JSON"-style naming conventions, so by default field names in records are now converted to snake-case 